### PR TITLE
Make it possible to send HTML mails

### DIFF
--- a/src/lib/api/v1/schema/send.ts
+++ b/src/lib/api/v1/schema/send.ts
@@ -1,5 +1,21 @@
 import { z } from '@hono/zod-openapi'
 
+/*
+ * Schema for mail body content
+ */
+const MailBodyContentSchema = z.object({
+  text: z
+    .string({
+      required_error: 'This field is required',
+    })
+    .openapi({
+      example: 'Body content in plain text',
+    }),
+  html: z.string().optional().openapi({
+    example: 'Body content in HTML',
+  }),
+})
+
 /**
  * Schema for request of POST /send
  */
@@ -14,14 +30,10 @@ export const SendApiRequestSchemaV1 = z.object({
     .openapi({
       example: 'This is a subject',
     }),
-  body: z
-    .string({
-      required_error: 'This field is required',
-    })
-    .openapi({
-      example: 'This is a body',
-    }),
+  body: MailBodyContentSchema,
 })
+
+export type SendApiRequestV1 = z.infer<typeof SendApiRequestSchemaV1>
 
 /**
  * Schema for response of POST /send
@@ -33,7 +45,7 @@ export const SendApiResponseSchemaV1 = z.object({
 })
 
 /**
- * Schema for Zod validation error (internal use)
+ * Schema for Zod validation error
  */
 const ZodValidationError = z.object({
   code: z.string(),

--- a/src/lib/mail/ses.test.ts
+++ b/src/lib/mail/ses.test.ts
@@ -21,7 +21,10 @@ describe('sendEmailWithSES', () => {
     fromAddress: 'test@example.com',
     toAddress: 'to@example.com',
     subject: 'Test',
-    body: 'Hello world',
+    body: {
+      text: 'Hello world',
+      html: '<p>Hello World!</p>',
+    },
   }
 
   const credentials: SESv2ClientConfig['credentials'] = {

--- a/src/lib/mail/ses.ts
+++ b/src/lib/mail/ses.ts
@@ -24,8 +24,12 @@ export const sendEmailWithSES = async (
     Content: {
       Simple: {
         Body: {
+          Text: {
+            Data: body.text,
+            Charset: 'UTF-8',
+          },
           Html: {
-            Data: body,
+            Data: body.html,
             Charset: 'UTF-8',
           },
         },

--- a/src/types/Mail.ts
+++ b/src/types/Mail.ts
@@ -2,5 +2,8 @@ export type Mail = {
   fromAddress: string
   toAddress: string
   subject: string
-  body: string
+  body: {
+    text: string
+    html?: string
+  }
 }


### PR DESCRIPTION
## 🎲 Issue 番号 / Issue ID

- Close #4 

## ✍️ 目的 / Purpose
テキストメールだけでなく、HTMLメールを送れるよう変更する。
<!--
  その変更を提案する意図をご説明ください。どの問題が解決したり、機能的な追加がなされたりしますか。
  Describe the intention of the changes being proposed. What problem does it solve or functionality does it add?
-->

## ⛏ 変更内容 / Details of Changes

<!--
  変更を端的に箇条書きで書いてください。
  List down your changes concisely.
-->

- Mail typeを変更し、bodyの内容として、プレーンテキストとHTML両方を設定できるように変更した
- OpenAPI仕様を更新した

## 📝 その他

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
