### PR TITLE
Update Dependabot configuration to reduce open pull requests limit and refine dependency groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 7
     groups:
-      test:
+      dev:
+        dependency-type: development
+        exclude-patterns:
+          - "@cloudflare/workers-types"
+          - wrangler
+      wrangler:
         patterns:
-          - "@vitest/*"
-          - "vitest*"
+          - "@cloudflare/workers-types"
+          - wrangler


### PR DESCRIPTION
## 🎲 Issue 番号 / Issue ID

- Close #

## ⛏ 変更内容 / Details of Changes
This pull request includes changes to the Dependabot configuration file to adjust the open pull requests limit and modify dependency groups.

Changes to Dependabot configuration:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L7-R17): Reduced the `open-pull-requests-limit` from 10 to 7.
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L7-R17): Renamed the `test` group to `dev` and added `dependency-type: development` along with exclude patterns for `@cloudflare/workers-types` and `wrangler`.
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L7-R17): Created a new `wrangler` group with patterns for `@cloudflare/workers-types` and `wrangler`.
## 📝 その他
N/A
<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
