### PR TITLE
Add Claude PR Assistant workflow for automated comments and reviews

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,36 @@
+name: Claude PR Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude-code-action:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude PR Action
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          timeout_minutes: "60"


### PR DESCRIPTION
## Summary
This pull request introduces a new GitHub Actions workflow to automate interactions with Claude, an AI assistant, for pull requests and issues. The workflow listens for specific events and triggers the Claude action when certain conditions are met.

### New GitHub Actions Workflow:

* [`.github/workflows/claude.yml`](diffhunk://#diff-53fec9c265fdba82268df5cd90315b8da57cce43d8e20efbf5c0bdcd1de1342eR1-R36): Added a workflow named "Claude PR Assistant" that triggers on events like issue comments, pull request review comments, and issues when they contain mentions of `@claude`. It uses the `anthropics/claude-code-action` to process these events, with appropriate permissions and a configurable timeout.