### PR TITLE
fix: Remove unused D1 database configuration from wrangler.json

### DIFF
--- a/wrangler.json
+++ b/wrangler.json
@@ -11,14 +11,6 @@
 		"enabled": true,
 		"head_sampling_rate": 1
 	},
-	"d1_databases": [
-		{
-			"binding": "DB",
-			"database_name": "mail-service-log",
-			"database_id": "${PRODUCTION_MAIL_SERVICE_LOG_DB_ID}",
-			"migrations_dir": "migrations"
-		}
-	],
 	"r2_buckets": [
 		{
 			"binding": "MAIL_LOGS_BUCKET",


### PR DESCRIPTION
## 🎲 Issue 番号 / Issue ID

- Close

## ⛏ 変更内容 / Details of Changes
This pull request removes the `d1_databases` configuration from the `wrangler.json` file, which previously defined a database binding for `mail-service-log`. This change simplifies the configuration by eliminating unused or unnecessary database settings.

Configuration cleanup:

* [`wrangler.json`](diffhunk://#diff-af47c12c8c97a3488240bdb6361b1f8ae3be4789a5eea74a1bd0de8b321f7412L14-L21): Removed the `d1_databases` section, including the binding for `DB`, the `mail-service-log` database name, and related configurations such as `database_id` and `migrations_dir`.
<!--
  変更を端的に箇条書きで書いてください。
  List down your changes concisely.
-->

## 📝 その他
N/A
<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
